### PR TITLE
Added command to use /bin/bash rather than JShell as default terminal for kafka-tools

### DIFF
--- a/docker-compose.tools.yml
+++ b/docker-compose.tools.yml
@@ -5,5 +5,6 @@ services:
       context: ./kafka-tools
     stdin_open: true
     tty: true
+    command: /bin/bash
     volumes:
       - ./data:/root/data


### PR DESCRIPTION
This PR should fix the trouble a couple of us had on the July training session at Digio.

It looks like there was a downstream dependency change somewhere on OpenJDK that had jshell as a dependency.

It looks like those who completed the prerequisites for the course before a certain date were fine, but those who did it afterwards were affected. Hopefully this will avoid teething problems during future presentations of the course. 